### PR TITLE
Adds elevation prop to surface components

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -15,6 +15,7 @@ export class Calendar extends React.Component<CalendarProps, State> {
     date: new Date(),
     cellRender: ([, , date]) => date,
     disabledDate: () => false,
+    elevation: 0,
   };
 
   constructor(props: CalendarProps) {
@@ -184,7 +185,7 @@ export class Calendar extends React.Component<CalendarProps, State> {
     return (
       <ThemeConsumer>
         {(theme) => (
-          <Card>
+          <Card elevation={this.props.elevation}>
             <CardBody>
               <div>
                 <Row>
@@ -370,6 +371,7 @@ export interface CalendarProps {
     color?: string;
   }[];
 
+  elevation?: number;
   onClick?: (date: DateTupple) => void;
   disabledDate?: (date: DateTupple) => boolean;
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { stylesheet, classes } from 'typestyle';
 import { ThemeConsumer, Theme } from '../Theme/Theme';
-import { shadow } from '../../helpers/style';
 import elevations from '../../helpers/elevations';
 
 export const Card: React.FunctionComponent<CardProps> = (props) => {
@@ -25,7 +24,6 @@ export const Card: React.FunctionComponent<CardProps> = (props) => {
 const style = (theme: Theme) => {
   return stylesheet({
     container: {
-      boxShadow: shadow('2X', theme),
       background: theme.background,
       boxSizing: 'border-box',
       padding: '16px',

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { Portal } from '../Popover/Portal';
-import { style, keyframes } from 'typestyle';
+import { style, keyframes, stylesheet, classes } from 'typestyle';
 import { NestedCSSProperties } from 'typestyle/lib/types';
 import { Theme, ThemeConsumer } from '../Theme/Theme';
+import elevations from '../../helpers/elevations';
 
 export const Drawer: React.FunctionComponent<DrawerProps> = (props) => {
+  const { elevation = 0 } = props;
+
   if (!props.isVisible) {
     document.body.style.overflow = 'auto';
     document.body.style.position = '';
@@ -17,28 +20,34 @@ export const Drawer: React.FunctionComponent<DrawerProps> = (props) => {
   return (
     <Portal>
       <ThemeConsumer>
-        {(theme) => (
-          <>
-            <div className={MaskStyle()} onClick={() => props.onClose && props.onClose()} />
-            <div style={props.style.container} className={DrawerStyle(props, theme)}>
-              {props.header && (
-                <div style={props.style.header} className="header">
-                  {props.header}
-                </div>
-              )}
+        {(theme) => {
+          const css = elevationCss(theme);
+          return (
+            <>
+              <div className={MaskStyle()} onClick={() => props.onClose && props.onClose()} />
+              <div
+                style={props.style.container}
+                className={classes(DrawerStyle(props, theme), css[`elevation${elevation}`])}
+              >
+                {props.header && (
+                  <div style={props.style.header} className="header">
+                    {props.header}
+                  </div>
+                )}
 
-              <div style={props.style.body} className="body">
-                {props.children}
+                <div style={props.style.body} className="body">
+                  {props.children}
+                </div>
+
+                {props.footer && (
+                  <div style={props.style.footer} className="footer">
+                    {props.footer}
+                  </div>
+                )}
               </div>
-
-              {props.footer && (
-                <div style={props.style.footer} className="footer">
-                  {props.footer}
-                </div>
-              )}
-            </div>
-          </>
-        )}
+            </>
+          );
+        }}
       </ThemeConsumer>
     </Portal>
   );
@@ -55,6 +64,8 @@ const MaskStyle = () =>
     bottom: '0',
     background: 'rgba(0, 0, 0, 0.5)',
   });
+
+const elevationCss = (theme) => stylesheet({ ...elevations(theme) });
 
 const DrawerStyle = (props: DrawerProps, theme: Theme) => {
   const styles: NestedCSSProperties[] = [
@@ -79,6 +90,7 @@ const DrawerStyle = (props: DrawerProps, theme: Theme) => {
           borderTop: '1px solid #ccc',
         },
       },
+      ...elevations(theme),
     },
   ];
 
@@ -212,4 +224,5 @@ export interface DrawerProps {
    * Callback to be triggered when clicked on close(X) or on mask
    */
   onClose?: () => void;
+  elevation?: number;
 }

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -3,7 +3,6 @@ import { stylesheet } from 'typestyle';
 
 import { MdMenu, MdKeyboardArrowLeft } from 'react-icons/md';
 import { Button } from '../../index';
-import { shadow } from '../../helpers/style';
 import { ThemeConsumer, Theme } from '../Theme/Theme';
 import { COLLAPSED_WIDTH, SidePanelContext } from './Container';
 
@@ -32,7 +31,7 @@ export const SidePanel: React.FunctionComponent<SidePanelProps> = (props) => {
                   </div>
                 </div>
                 <div className={css.line} />
-                <div className={css.top}>{props.children}</div>
+                <div>{props.children}</div>
                 <div className={css.bottom}>{props.bottom}</div>
               </aside>
               // </SidePanelContext.Provider>
@@ -53,14 +52,10 @@ const style = (open: boolean, theme: Theme, width: number) => {
       height: '100vh',
       maxHeight: '100%',
       background: open ? theme.background : 'none',
-      boxShadow: open && shadow('2X', theme),
       transition: '.3s all',
       zIndex: 1,
       left: 0,
       top: 0,
-    },
-    top: {
-      boxShadow: !open && shadow('2X', theme),
     },
     line: {
       width: !open && '3px',
@@ -111,7 +106,6 @@ const style = (open: boolean, theme: Theme, width: number) => {
       position: 'absolute',
       bottom: 0,
       width: '100%',
-      boxShadow: !open && shadow('2X', theme),
     },
   });
 };

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Meta } from '@storybook/react';
+import { Story, Meta } from '@storybook/react';
 
 import { List, ListItem, CollapsibleList } from '../List';
+import { ListProps } from './List';
 import { MdAcUnit, Md3DRotation, MdAccessAlarm } from 'react-icons/md';
 import { Divider } from '../Divider';
 
@@ -14,8 +15,8 @@ export default {
   },
 } as Meta;
 
-export const Basic = () => (
-  <List>
+export const Basic: Story<ListProps<any>> = (args) => (
+  <List {...args}>
     <ListItem avatar={<MdAcUnit />}>Basic Item List</ListItem>
     <ListItem avatar={<Md3DRotation />}>Basic Item List</ListItem>
     <Divider />
@@ -24,8 +25,8 @@ export const Basic = () => (
   </List>
 );
 
-export const Subtitle = () => (
-  <List>
+export const Subtitle: Story<ListProps<any>> = (args) => (
+  <List {...args}>
     <ListItem avatar={<MdAcUnit />} subtitle="Do you Know Lorem Ipsum?">
       Basic Item List
     </ListItem>
@@ -39,8 +40,8 @@ export const Subtitle = () => (
   </List>
 );
 
-export const Collapsible = () => (
-  <List>
+export const Collapsible: Story<ListProps<any>> = (args) => (
+  <List {...args}>
     <ListItem avatar={<MdAcUnit />} subtitle="Do you Know Lorem Ipsum?">
       Basic Item List
     </ListItem>

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { classes } from 'typestyle';
 import { ThemeConsumer } from '../Theme/Theme';
 import { style } from './style';
 import { PaperProps } from '../Paper';
@@ -8,15 +9,18 @@ export interface ListProps<T> extends PaperProps {
   children?: React.ReactNode;
   render?: (data: T) => React.ReactNode;
   style?: React.CSSProperties;
+  elevation?: number;
 }
 
 export const List: React.FC<ListProps<unknown>> = (props) => {
+  const { elevation = 0 } = props;
+
   return (
     <ThemeConsumer>
       {(theme) => {
         const css = style(theme, props);
         return (
-          <div>
+          <div className={classes(css[`elevation${elevation}`])}>
             <ul className={css.list} style={props.style}>
               {props.children || props.data.map((v) => props.render(v))}
             </ul>

--- a/src/components/List/style.ts
+++ b/src/components/List/style.ts
@@ -3,6 +3,7 @@ import { Theme } from '../Theme/Theme';
 import { PaperProps } from '../Paper';
 import { shadow } from '../../helpers/style';
 import { hoverColor } from '../../helpers/color';
+import elevations from '../../helpers/elevations';
 
 export const style = (theme: Theme, __paper?: PaperProps) => {
   return stylesheet({
@@ -31,5 +32,6 @@ export const style = (theme: Theme, __paper?: PaperProps) => {
       overflowY: 'hidden',
       transition: 'all .6s cubic-bezier(0.4, 0, 0.2, 1)',
     },
+    ...elevations(theme),
   });
 };

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Portal } from '../Popover/Portal';
-import { style as typeStyle, keyframes } from 'typestyle';
+import { style as typeStyle, stylesheet, keyframes, classes } from 'typestyle';
 import { shadow } from '../../helpers/style';
 import { Theme, ThemeConsumer } from '../Theme/Theme';
 import { colorShades } from '../../helpers/color';
+import elevations from '../../helpers/elevations';
 
 export const Modal: React.FunctionComponent<ModalProps> = (props) => {
-  const { children, onClose, isVisible, style = {}, width } = props;
+  const { children, onClose, isVisible, style = {}, width, elevation = 0 } = props;
 
   if (!isVisible) {
     document.body.style.overflow = 'auto';
@@ -20,18 +21,21 @@ export const Modal: React.FunctionComponent<ModalProps> = (props) => {
   return (
     <Portal key="modal">
       <ThemeConsumer>
-        {(theme) => (
-          <div key="mask" className={MaskStyle} onClick={() => onClose && onClose()}>
-            <div
-              key="container"
-              className={containerStyle(theme)}
-              style={{ ...style, width }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div>{children}</div>
+        {(theme) => {
+          const css = modalStyle(theme);
+          return (
+            <div key="mask" className={MaskStyle} onClick={() => onClose && onClose()}>
+              <div
+                key="container"
+                className={classes(css.container, css[`elevation${elevation}`])}
+                style={{ ...style, width }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div>{children}</div>
+              </div>
             </div>
-          </div>
-        )}
+          );
+        }}
       </ThemeConsumer>
     </Portal>
   );
@@ -48,17 +52,21 @@ const slideInBottom = keyframes({
   },
 });
 
-const containerStyle = (theme: Theme) =>
-  typeStyle({
-    maxHeight: '70vh',
-    background: colorShades(theme.background)[1],
-    zIndex: 1001,
-    top: '10vh',
-    boxShadow: shadow('2X', theme),
-    overflowY: 'auto',
-    width: '50vw',
-    animation: `${slideInBottom} 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) both`,
+const modalStyle = (theme: Theme) => {
+  return stylesheet({
+    container: {
+      maxHeight: '70vh',
+      background: colorShades(theme.background)[1],
+      zIndex: 1001,
+      top: '10vh',
+      boxShadow: shadow('2X', theme),
+      overflowY: 'auto',
+      width: '50vw',
+      animation: `${slideInBottom} 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) both`,
+    },
+    ...elevations(theme),
   });
+};
 
 const MaskStyle = typeStyle({
   position: 'fixed',
@@ -81,4 +89,5 @@ export interface ModalProps {
   style?: React.CSSProperties;
   isVisible?: boolean;
   onClose?: () => void;
+  elevation?: number;
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Portal } from '../Popover/Portal';
 import { style as typeStyle, stylesheet, keyframes, classes } from 'typestyle';
-import { shadow } from '../../helpers/style';
 import { Theme, ThemeConsumer } from '../Theme/Theme';
 import { colorShades } from '../../helpers/color';
 import elevations from '../../helpers/elevations';
@@ -59,7 +58,6 @@ const modalStyle = (theme: Theme) => {
       background: colorShades(theme.background)[1],
       zIndex: 1001,
       top: '10vh',
-      boxShadow: shadow('2X', theme),
       overflowY: 'auto',
       width: '50vw',
       animation: `${slideInBottom} 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) both`,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { stylesheet } from 'typestyle';
+import { stylesheet, classes } from 'typestyle';
 import RCTooltip from 'rc-tooltip';
 import { isBrowser } from '../../helpers';
 import { ThemeConsumer, Theme } from '../Theme/Theme';
 import { shadow } from '../../helpers/style';
+import elevations from '../../helpers/elevations';
 
 export class Popover extends React.Component<PopoverProps, State> {
   public static defaultProps: Partial<PopoverProps> = {
@@ -65,6 +66,7 @@ export class Popover extends React.Component<PopoverProps, State> {
       position,
       style: { container: containerStyle, child: childStyle },
       onVisibleChange,
+      elevation = 0,
     } = this.props;
 
     if (!this.state.isBrowser) {
@@ -85,7 +87,7 @@ export class Popover extends React.Component<PopoverProps, State> {
               trigger={[triggers(trigger)]}
               overlay={this.renderContent()}
               destroyTooltipOnHide={!preserveOnClose}
-              overlayClassName={css.container}
+              overlayClassName={classes(css.container, css[`elevation${elevation}`])}
               overlayStyle={containerStyle}
               onVisibleChange={(v) => {
                 this.setState({ visible: v });
@@ -123,6 +125,7 @@ function style(expand: boolean, childWidth: number, theme: Theme) {
       background: theme.background,
       color: `${theme.textColor} !important`,
     },
+    ...elevations(theme),
   });
 }
 
@@ -143,6 +146,7 @@ export interface PopoverProps {
   visible?: boolean;
   onVisibleChange?: (visible?: boolean) => void;
   align?: Record<string, unknown>;
+  elevation: number;
 }
 
 interface State {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -3,7 +3,6 @@ import { stylesheet, classes } from 'typestyle';
 import RCTooltip from 'rc-tooltip';
 import { isBrowser } from '../../helpers';
 import { ThemeConsumer, Theme } from '../Theme/Theme';
-import { shadow } from '../../helpers/style';
 import elevations from '../../helpers/elevations';
 
 export class Popover extends React.Component<PopoverProps, State> {
@@ -119,7 +118,6 @@ function style(expand: boolean, childWidth: number, theme: Theme) {
     container: {
       width: expand ? childWidth : 'auto',
       minWidth: '100px',
-      boxShadow: shadow('2X', theme),
       borderRadius: '2px',
       padding: '0',
       background: theme.background,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,7 +3,6 @@ import { stylesheet, classes } from 'typestyle';
 import { GiEmptyMetalBucket } from 'react-icons/gi';
 import { Theme, ThemeConsumer } from '../Theme/Theme';
 import { lightText, borderColor } from '../../helpers/color';
-import { shadow } from '../../helpers/style';
 import { Text } from '../Text';
 import elevations from '../../helpers/elevations';
 
@@ -42,11 +41,11 @@ export class Table<T> extends React.Component<TableProps<T>, never> {
   };
 
   render() {
-    const { header, columns, footer, shadow: shadowEnabled } = this.props;
+    const { header, columns, footer } = this.props;
     return (
       <ThemeConsumer>
         {(theme) => {
-          const css = style(shadowEnabled, theme);
+          const css = style(theme);
           return (
             <div className={classes(css.container, css[`elevation${this.props.elevation}`])}>
               {header && (
@@ -74,8 +73,7 @@ export class Table<T> extends React.Component<TableProps<T>, never> {
   }
 }
 
-const style = (shadowEnabled: boolean, theme: Theme) => {
-  const shadow2x = shadow('2X', theme);
+const style = (theme: Theme) => {
   return stylesheet({
     table: {
       width: '100%',
@@ -123,7 +121,6 @@ const style = (shadowEnabled: boolean, theme: Theme) => {
       },
     },
     container: {
-      boxShadow: shadowEnabled && shadow2x,
       background: theme.background,
     },
     icon: {
@@ -151,7 +148,6 @@ const style = (shadowEnabled: boolean, theme: Theme) => {
 export interface TableProps<T> {
   data: T[];
   columns: Colums<T>[];
-  shadow?: boolean;
   elevation?: number;
   header?: React.ReactNode;
   footer?: React.ReactNode;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
-import { stylesheet } from 'typestyle';
+import { stylesheet, classes } from 'typestyle';
 import { GiEmptyMetalBucket } from 'react-icons/gi';
 import { Theme, ThemeConsumer } from '../Theme/Theme';
 import { lightText, borderColor } from '../../helpers/color';
 import { shadow } from '../../helpers/style';
 import { Text } from '../Text';
+import elevations from '../../helpers/elevations';
 
 export class Table<T> extends React.Component<TableProps<T>, never> {
   static defaultProps = {
     shadow: true,
+    elevation: 0,
   };
 
   renderRow = () => {
@@ -46,7 +48,7 @@ export class Table<T> extends React.Component<TableProps<T>, never> {
         {(theme) => {
           const css = style(shadowEnabled, theme);
           return (
-            <div className={css.container}>
+            <div className={classes(css.container, css[`elevation${this.props.elevation}`])}>
               {header && (
                 <Text variant="h6" className={css.header}>
                   {header}
@@ -142,6 +144,7 @@ const style = (shadowEnabled: boolean, theme: Theme) => {
     footer: {
       padding: '12px 24px 8px',
     },
+    ...elevations(theme),
   });
 };
 
@@ -149,6 +152,7 @@ export interface TableProps<T> {
   data: T[];
   columns: Colums<T>[];
   shadow?: boolean;
+  elevation?: number;
   header?: React.ReactNode;
   footer?: React.ReactNode;
 }

--- a/src/components/Transfer/Transfer.tsx
+++ b/src/components/Transfer/Transfer.tsx
@@ -14,6 +14,7 @@ export interface TransferProps<T> {
   searchValue?: (value: T) => string;
   onChange?: (values: T[]) => void;
   values?: T[];
+  elevation?: number;
 }
 
 interface State<T> {
@@ -41,6 +42,7 @@ export class Transfer<T> extends React.Component<TransferProps<T>, State<T>> {
 
   static defaultProps = {
     searchValue: (e) => String(e),
+    elevation: 0,
   };
 
   componentDidMount() {
@@ -160,7 +162,7 @@ export class Transfer<T> extends React.Component<TransferProps<T>, State<T>> {
   render() {
     const { selectedLeft, selectedRight, data } = this.state;
     return (
-      <Card style={{ minWidth: '500px' }}>
+      <Card elevation={this.props.elevation} style={{ minWidth: '500px' }}>
         <Row alignItems="center">
           <Col span={10} alignSelf="stretch">
             <CardHeader subtitle={`${data.length} item(s)`} />


### PR DESCRIPTION
Adds material elevation prop for Surface components for light and dark theme, ranging from 0-24.

### Components with elevation props
- [x] Table
- [x] Transfer
- [x] Calendar
- [x] Collapse, List
- [x] Drawer
- [ ] Side Panel [Can't add-- it's using context]
- [x] Modal
- [x] Popover

Issue https://github.com/sha-el/sha-el-design/issues/11