### PR TITLE
🐛 Fix timepicker test fail at 12am/pm in 12 hour format

### DIFF
--- a/__tests__/components/DatePicker/TimePicker.spec.tsx
+++ b/__tests__/components/DatePicker/TimePicker.spec.tsx
@@ -292,7 +292,7 @@ describe('TimePicker', () => {
     const timePickerContainer = document.querySelector('.rc-tooltip').querySelector('.sha-el-row');
 
     const hours = timePickerContainer.querySelector('.hour-column').querySelectorAll('p');
-    expect(hours[Number(currentTime[0])]).toHaveStyle(`
+    expect(hours[Number(currentTime[0] === '12' ? '0' : currentTime[0])]).toHaveStyle(`
       background: #536DFE;
     `);
 


### PR DESCRIPTION
# PR Details

## Description

* Fix TimePicker test fail at 12am/pm because hours array at index 12 is now null since hours array at index 0 is 12 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
